### PR TITLE
Add separate sensors for power and current

### DIFF
--- a/esphome/components/emporia_vue/emporia_vue.h
+++ b/esphome/components/emporia_vue/emporia_vue.h
@@ -51,7 +51,7 @@ class EmporiaVueComponent : public Component, public i2c::I2CDevice {
   void set_sensor_poll_interval(uint32_t sensor_poll_interval) { this->sensor_poll_interval_ = sensor_poll_interval; }
   uint32_t get_sensor_poll_interval() const { return this->sensor_poll_interval_; }
   void set_phases(std::vector<PhaseConfig *> phases) { this->phases_ = std::move(phases); }
-  void set_ct_clamps(std::vector<CTClampConfig *> ct_clamps) { this->ct_clamps_ = ct_clamps; }
+  void set_ct_clamps(std::vector<CTClampConfig *> ct_clamps) { this->ct_clamps_ = std::move(ct_clamps); }
 #ifdef USING_OTA_COMPONENT
   void set_ota(ota::OTAComponent *ota) { this->ota_ = ota; }
 #endif

--- a/esphome/components/emporia_vue/emporia_vue.h
+++ b/esphome/components/emporia_vue/emporia_vue.h
@@ -42,7 +42,7 @@ struct __attribute__((__packed__)) SensorReading {
 };
 
 class PhaseConfig;
-class CTSensor;
+class CTClampConfig;
 
 class EmporiaVueComponent : public Component, public i2c::I2CDevice {
  public:
@@ -50,8 +50,8 @@ class EmporiaVueComponent : public Component, public i2c::I2CDevice {
 
   void set_sensor_poll_interval(uint32_t sensor_poll_interval) { this->sensor_poll_interval_ = sensor_poll_interval; }
   uint32_t get_sensor_poll_interval() const { return this->sensor_poll_interval_; }
-  void set_phases(std::vector<PhaseConfig *> phases) { this->phases_ = std::move(phases); }
-  void set_ct_sensors(std::vector<CTSensor *> sensors) { this->ct_sensors_ = std::move(sensors); }
+  void set_phases(std::vector<PhaseConfig *> phases) { this->phases_ = phases; }
+  void set_ct_clamps(std::vector<CTClampConfig *> ct_clamps) { this->ct_clamps_ = ct_clamps; }
 #ifdef USING_OTA_COMPONENT
   void set_ota(ota::OTAComponent *ota) { this->ota_ = ota; }
 #endif
@@ -64,7 +64,7 @@ class EmporiaVueComponent : public Component, public i2c::I2CDevice {
 
   uint32_t sensor_poll_interval_;
   std::vector<PhaseConfig *> phases_;
-  std::vector<CTSensor *> ct_sensors_;
+  std::vector<CTClampConfig *> ct_clamps_;
   QueueHandle_t i2c_data_queue_;
 #ifdef USING_OTA_COMPONENT
   ota::OTAComponent *ota_{nullptr};
@@ -119,12 +119,16 @@ enum CTInputPort : uint8_t {
   SIXTEEN = 18,
 };
 
-class CTSensor : public sensor::Sensor {
+class CTClampConfig : public sensor::Sensor {
  public:
   void set_phase(PhaseConfig *phase) { this->phase_ = phase; };
   const PhaseConfig *get_phase() const { return this->phase_; }
   void set_input_port(CTInputPort input_port) { this->input_port_ = input_port; };
   CTInputPort get_input_port() const { return this->input_port_; }
+  void set_power_sensor(sensor::Sensor *power_sensor) { this->power_sensor_ = power_sensor; }
+  sensor::Sensor *get_power_sensor() const { return this->power_sensor_; }
+  void set_current_sensor(sensor::Sensor *current_sensor) { this->current_sensor_ = current_sensor; }
+  sensor::Sensor *get_current_sensor() const { return this->current_sensor_; }
 
   void update_from_reading(const SensorReading &sensor_reading);
   float get_calibrated_power(int32_t raw_power) const;
@@ -132,6 +136,8 @@ class CTSensor : public sensor::Sensor {
  protected:
   PhaseConfig *phase_;
   CTInputPort input_port_;
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
 };
 
 }  // namespace emporia_vue

--- a/esphome/components/emporia_vue/emporia_vue.h
+++ b/esphome/components/emporia_vue/emporia_vue.h
@@ -50,7 +50,7 @@ class EmporiaVueComponent : public Component, public i2c::I2CDevice {
 
   void set_sensor_poll_interval(uint32_t sensor_poll_interval) { this->sensor_poll_interval_ = sensor_poll_interval; }
   uint32_t get_sensor_poll_interval() const { return this->sensor_poll_interval_; }
-  void set_phases(std::vector<PhaseConfig *> phases) { this->phases_ = phases; }
+  void set_phases(std::vector<PhaseConfig *> phases) { this->phases_ = std::move(phases); }
   void set_ct_clamps(std::vector<CTClampConfig *> ct_clamps) { this->ct_clamps_ = ct_clamps; }
 #ifdef USING_OTA_COMPONENT
   void set_ota(ota::OTAComponent *ota) { this->ota_ = ota; }

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -184,19 +184,21 @@ sensor:
     phases:
       - id: phase_a
         input: BLACK
-        voltage: 
-          name: "Phase A Voltage"
       - id: phase_c
         input: RED
         voltage: 
           name: "Phase C Voltage"
     ct_clamps:
-      - name: "A"
-        phase_id: phase_a
+      - phase_id: phase_a
         input: "A"
-      - name: "C"
-        phase_id: phase_c
+        power:
+          name: "A Power"
+        current:
+          name: "A Current"
+      - phase_id: phase_c
         input: "C"
+        power:
+          name: "C Power"
 
 script:
   - id: automation_test


### PR DESCRIPTION
Moves the power sensors to be nested under the CT clamps; mainly so that when we figure out how the current sensors work, we won't need to make a breaking change to config